### PR TITLE
fix rdk response compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist/
+
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@retter/rio-generator",
-  "version": "1.2.7",
+  "version": "1.2.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@retter/rio-generator",
-      "version": "1.2.7",
+      "version": "1.2.10",
       "license": "ISC",
       "dependencies": {
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@retter/rio-generator",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "retter io proxy class helper generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/languages/server/typescript.ts
+++ b/src/languages/server/typescript.ts
@@ -104,7 +104,7 @@ interface RetterRequest<T> extends Omit<GetInstance, 'classId'|'body'> {
 }
 
 interface RetterResponse<T> extends CloudObjectResponse {
-    body?: T
+    body: T
 }
 
 ${interfaces.trim()}


### PR DESCRIPTION
Since we have required body response in `@retter/rdk@1.1.8`,  we need to remove optional body from `rio` files